### PR TITLE
Drag show page video

### DIFF
--- a/frontend/src/components/calendar/calendar.css
+++ b/frontend/src/components/calendar/calendar.css
@@ -88,14 +88,11 @@ div.slots{
 
 
 
-div.slot > figure:first-child{
-  height: 100%;
-  width: 100%;
-}
+
 
 figure {
-  width: 600px;
-  height: 450px;
+  width: 100%;
+  height: 100%;
   padding: 0;
 }
 

--- a/frontend/src/components/posts/post_show.jsx
+++ b/frontend/src/components/posts/post_show.jsx
@@ -4,6 +4,8 @@ import ReactPlayer from "react-player/file";
 import "./post_show.css";
 import Comments from '../comments/comments';
 import {Link} from 'react-router-dom';
+import DraggableVideo from "../calendar/draggablevideo";
+
 class PostShow extends Component {
   constructor(props) {
     super(props);
@@ -99,20 +101,25 @@ class PostShow extends Component {
             </p>
           </div>
           <div className="show-video-container">
-            <ReactPlayer
-              ref={this.vidRef}
-              url={post.url}
-              controls
-              height={"inherit"}
-              width={"inherit"}
-              config={{
-                file: {
-                  attributes: {
-                    controlsList: ["nodownload"],
-                    disablePictureInPicture: true,
-                  },
-                },
-              }}
+            <DraggableVideo
+              id = {this.props.post._id}
+              contents = {
+                <ReactPlayer
+                  ref={this.vidRef}
+                  url={post.url}
+                  controls
+                  height={"inherit"}
+                  width={"inherit"}
+                  config={{
+                    file: {
+                      attributes: {
+                        controlsList: ["nodownload"],
+                        disablePictureInPicture: true,
+                      },
+                    },
+                  }}
+                />
+              }
             />
           </div>
           <div className="video-info">

--- a/frontend/src/components/videos/feed_video.css
+++ b/frontend/src/components/videos/feed_video.css
@@ -93,6 +93,7 @@
   width: inherit;
   position: absolute;
   
+  
   /* top: 0; */
   /* z-index: 20; */
 }


### PR DESCRIPTION
Draggable Videos fit 100% width and height of container and you can now drag the show page video into the calendar.