### PR TITLE
Remove background-position in login-form and signup-form

### DIFF
--- a/frontend/src/components/modal/modal.css
+++ b/frontend/src/components/modal/modal.css
@@ -54,7 +54,6 @@
   background-image: url('./marble.jpg');
   background-size: cover;
   background-attachment: fixed;
-  background-position: 28em 18em;
   background-repeat: no-repeat;
 }
 


### PR DESCRIPTION
Oh Firefox, the marble background was only partially showing up for session modals, like this:

![firefox-error](https://user-images.githubusercontent.com/4776715/103498619-71788100-4e13-11eb-81bf-5e1cbee95373.png)

Removing the `background-position` attribute fixes the issue and maintains the expected behaviour on Chrome.
