### PR TITLE
Put redux-logger back into dependencies to stop error

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,14 +30,12 @@
     "react-spring": "^8.0.27",
     "react-use-gesture": "^8.0.1",
     "redux": "^4.0.5",
+    "redux-logger": "^3.0.6",
     "redux-thunk": "^2.3.0",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.1",
     "spring": "0.0.0",
     "web-vitals": "^0.2.4"
-  },
-  "devDependencies": {
-    "redux-logger": "^3.0.6"
   },
   "scripts": {
     "start": "react-app-rewired start",


### PR DESCRIPTION
There was an issue with my last PR. It tried to import `redux-logger` but couldn't find it because it had been moved to `devDependencies`. This makes sense, but for some reason the error wasn't coming up in my fullstack, where I first tried this strategy out.