### PR TITLE
Redirect to show page of successful upload

### DIFF
--- a/frontend/src/components/posts/create_post_form.js
+++ b/frontend/src/components/posts/create_post_form.js
@@ -63,17 +63,17 @@ class CreatePostForm extends React.Component {
     uploadFile(video, config).then(
       data => {
 
-        const post = {
+        const postData = {
           title: this.state.title,
           url: data.location,
           nutrition: this.state.nutrition,
           diet: this.state.diet,
           ingredients: this.state.ingredients
         }
-        this.props.createPost(post).then(() => {
+        this.props.createPost(postData).then(({ post }) => {
            this.props.loadingOff();
            this.props.clearPostErrors();
-           this.props.history.push('/feed')
+           this.props.history.push(`/show/${post.data._id}`)
         })
       }
 


### PR DESCRIPTION
Rather than just redirect to the feed, a successful upload will redirect to the appropriate show page. I think this would be the expected behaviour.