### PR TITLE
Use correct syntax in post actions for implicit return

### DIFF
--- a/frontend/src/actions/post_actions.js
+++ b/frontend/src/actions/post_actions.js
@@ -38,49 +38,49 @@ export const removePost = (postId) => ({
   postId,
 });
 
-export const createPost = (post) => (dispatch) =>
-  APIUtil.createPost(post).then(
+export const createPost = (post) => (dispatch) => {
+  return APIUtil.createPost(post).then(
     (post) => dispatch(receiveNewPost(post)),
     (err) => dispatch(receivePostErrors(err.response.data))
   );
+};
 
 export const fetchPosts = () => (dispatch) => {
-  return APIUtil.fetchPosts().then((posts) =>
-    dispatch(receivePosts(posts.data))
+  return APIUtil.fetchPosts().then(
+    (posts) => dispatch(receivePosts(posts.data))
   );
 };
 
 export const fetchUserPosts = (userId) => (dispatch) => {
-  return APIUtil.fetchUserPosts(userId).then((posts) => {
-    dispatch(receivePosts(posts.data));
-  });
+  return APIUtil.fetchUserPosts(userId).then(
+    (posts) => dispatch(receivePosts(posts.data))
+  );
 };
 
 export const fetchPost = (postId) => (dispatch) =>
-  APIUtil.fetchPost(postId).then((post) => {
-    dispatch(receivePost(post.data))
-  });
+  APIUtil.fetchPost(postId).then(
+    (post) => dispatch(receivePost(post.data))
+  );
 
 export const savePost = (postId, body) => (dispatch) => {
-  return APIUtil.savePost(postId, body).then((user) => {
-    dispatch(receiveUser(user));
-  });
+  return APIUtil.savePost(postId, body).then(
+    (user) => dispatch(receiveUser(user)));
 };
 
 export const unsavePost = (postId, userId) => (dispatch) => {
-  return APIUtil.unsavePost(postId, userId).then((user) =>
-    dispatch(receiveUser(user))
+  return APIUtil.unsavePost(postId, userId).then(
+    (user) => dispatch(receiveUser(user))
   );
 };
 
 export const editPost = (postId, newData) => (dispatch) => {
-  return APIUtil.editPost(postId, newData).then((post) => {
-    dispatch(receivePost(post.data));
-  });
+  return APIUtil.editPost(postId, newData).then(
+    (post) => dispatch(receivePost(post.data))
+  );
 };
 
 export const deletePost = (postId) => (dispatch) => {
-  return APIUtil.deletePost(postId).then((postId) => {
-    dispatch(removePost(postId));
-  });
+  return APIUtil.deletePost(postId).then(
+    (postId) => dispatch(removePost(postId))
+  );
 };


### PR DESCRIPTION
One of the recent commits changed the `fetchPost` action's `then` function, breaking the function into two lines and therefore removing the implicit return that was needed for the editing page. I've changed the style for all post actions so that they all return their data.